### PR TITLE
Use Diplomat instead of Consul-Client

### DIFF
--- a/capistrano-consul_kv_lock.gemspec
+++ b/capistrano-consul_kv_lock.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 3"
-  spec.add_dependency "consul-client"
+  spec.add_dependency "diplomat"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/capistrano/consul_kv_lock/latch.rb
+++ b/lib/capistrano/consul_kv_lock/latch.rb
@@ -71,7 +71,7 @@ module Capistrano
       end
 
       def lock
-        with_session { Diplomat::Lock.acquire(lock_key, @session_id) }
+        with_session { Diplomat::Lock.acquire(lock_key, @session_id, "true") }
       end
 
       def unlock

--- a/lib/capistrano/consul_kv_lock/latch.rb
+++ b/lib/capistrano/consul_kv_lock/latch.rb
@@ -34,7 +34,7 @@ module Capistrano
         @lock_key = options[:consul_lock_key] || 'deployment/locked'
         @session_id = nil
       end
-      attr_reader :client, :lock_key
+      attr_reader :lock_key
 
       def logger
         self.class.logger

--- a/lib/capistrano/consul_kv_lock/latch.rb
+++ b/lib/capistrano/consul_kv_lock/latch.rb
@@ -48,7 +48,7 @@ module Capistrano
       end
 
       def locked?
-        !!Diplomat::Kv.get(lock_key)
+        !!(Diplomat::Kv.get(lock_key) =~ /\A["'](t(rue)?|1|y(es)?)["']\z/)
       rescue => e
         # in case of 404
         if e.message.include?('404')

--- a/lib/capistrano/consul_kv_lock/latch.rb
+++ b/lib/capistrano/consul_kv_lock/latch.rb
@@ -30,10 +30,7 @@ module Capistrano
       end
 
       def initialize(consul_url, options={})
-        @client = begin
-                   consul = URI.parse(consul_url)
-                   Consul::Client.v1.http(host: consul.host, port: consul.port, logger: logger)
-                  end
+        Diplomat.configuration.url = consul_url
         @lock_key = options[:consul_lock_key] || 'deployment/locked'
         @session_id = nil
       end
@@ -51,9 +48,9 @@ module Capistrano
       end
 
       def locked?
-        r = client.get("/kv/#{lock_key}")
-        !!(Base64.decode64(r[0]['Value']) =~ /\A["'](t(rue)?|1|y(es)?)["']\z/)
-      rescue Consul::Client::ResponseException => e
+        r = Diplomat::Kv.get(lock_key)
+        !!(Base64.decode64(r.Value) =~ /\A["'](t(rue)?|1|y(es)?)["']\z/)
+      rescue => e
         # in case of 404
         if e.message.include?('404')
           return false
@@ -64,23 +61,22 @@ module Capistrano
 
       def create_session
         logger.debug "Session request: #{session_request.inspect}"
-        r = client.put("/session/create", session_request)
-        @session_id = r['ID']
+        @session_id = Diplomat::Session.create(session_request)
       end
 
       def delete_session
         with_session {
-          client.put("/session/destroy/#{@session_id}", "")
+          Diplomat::Session.destroy(@session_id)
         }
         @session_id = nil
       end
 
       def lock
-        with_session { client.put("/kv/#{lock_key}?acquire=#{@session_id}", "true") }
+        with_session { Diplomat::Lock.acquire(lock_key, @session_id) }
       end
 
       def unlock
-        with_session { client.put("/kv/#{lock_key}?release=#{@session_id}", "false") }
+        with_session { Diplomat::Lock.release(lock_key, @session_id) }
       end
 
       private

--- a/lib/capistrano/consul_kv_lock/latch.rb
+++ b/lib/capistrano/consul_kv_lock/latch.rb
@@ -48,8 +48,7 @@ module Capistrano
       end
 
       def locked?
-        r = Diplomat::Kv.get(lock_key)
-        !!(Base64.decode64(r.Value) =~ /\A["'](t(rue)?|1|y(es)?)["']\z/)
+        !!Diplomat::Kv.get(lock_key)
       rescue => e
         # in case of 404
         if e.message.include?('404')


### PR DESCRIPTION
[consul-client](https://github.com/xaviershay/consul-client) seems to be no-maintain status. so It shows warnings with `consul-client-0.1.1/lib/consul/client.rb:34: warning: circular argument reference - http` always.

I replaced `Diplomat` gem for consul communications. How about do you think this?
